### PR TITLE
fix(LandingPage): remove fade in flicker

### DIFF
--- a/modules/landing/LandingPage.tsx
+++ b/modules/landing/LandingPage.tsx
@@ -65,10 +65,16 @@ const LandingPage = () => {
           <FullscreenImage
             ref={backgroundImageRef}
             src="https://i.imgur.com/spPwj07.jpg"
-            style={{ opacity: backgroundOpacity }}
             onLoad={() => setBackgroundOpacity(1)}
           />
         </StackLayer>
+        <StackLayer
+          style={{
+            transition: "opacity 0.5s",
+            opacity: 1 - backgroundOpacity,
+            backgroundColor: "#000",
+          }}
+        />
         <StackLayer>
           <Container
             style={{


### PR DESCRIPTION
Blur filter causes image to flicker upon fade in. Solved by using
another element to cover the image instead of fading the image in.